### PR TITLE
Create first version of build tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+node_modules

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,40 @@
+{
+  "disallowMixedSpacesAndTabs": true,
+  "disallowSpaceAfterObjectKeys": true,
+  "disallowSpacesInAnonymousFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInFunctionDeclaration": {
+   "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInFunctionExpression": {
+   "beforeOpeningRoundBrace": true
+  },
+  "disallowSpacesInNamedFunctionExpression": {
+    "beforeOpeningRoundBrace": true
+  },
+  "disallowTrailingComma": true,
+  "requireLineFeedAtFileEnd": true,
+  "requireSpaceAfterKeywords": [
+    "if",
+    "else",
+    "for",
+    "while",
+    "do",
+    "switch",
+    "return",
+    "try",
+    "catch"
+  ],
+  "requireSpaceBeforeBlockStatements": true,
+  "requireSpacesInConditionalExpression": true,
+  "requireSpacesInFunctionExpression": {
+    "beforeOpeningCurlyBrace": true
+  },
+  "requireSpacesInsideObjectBrackets": "all",
+  "safeContextKeyword": ["self"],
+  "validateQuoteMarks": {
+    "escape": true,
+    "mark": "'"
+  }
+}

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,17 @@
+{
+  "node": true,
+  "browser": true,
+  "esnext": true,
+  "bitwise": true,
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "indent": 2,
+  "newcap": true,
+  "noarg": true,
+  "quotmark": "single",
+  "undef": true,
+  "unused": "vars",
+  "strict": true
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015 Mozilla
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # node-firefox-build-tools
-Common build tasks and configuration files for the node-firefox project
+
+Common build tasks and configuration files for the
+[node-firefox project](https://github.com/mozilla/node-firefox/).
+
+[![Install with NPM](https://nodei.co/npm/node-firefox-build-tools.png?downloads=true&stars=true)](https://nodei.co/npm/node-firefox-build-tools/)
+
+Right now this is just a set of common gulp tasks and style checks.
+
+## Usage
+
+Install first: `npm install --save-dev node-firefox-build-tools`.
+
+Then you can use it in your `gulpfile.js`:
+
+```javascript
+var gulp = require('gulp');
+var buildTools = require('node-firefox-build-tools');
+
+buildTools.loadGulpTasks(gulp);
+```
+
+## Available tasks
+
+#### `lint`
+
+> Run quality and style checks on your code.
+
+#### `nodeunit`
+
+> Run all nodeunit tests matching `tests/unit/**/test.*.js`
+
+#### `test`
+
+> Run linters and tests. You may want to override this task.
+
+## License
+
+This program is free software; it is distributed under an
+[Apache License](https://github.com/mozilla/node-firefox-build-tools/blob/master/LICENSE).
+
+## Copyright
+
+Copyright (c) 2015 [Mozilla](https://mozilla.org)
+([Contributors](https://github.com/mozilla/node-firefox-build-tools/graphs/contributors)).

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var gulp = require('gulp');
+var buildTools = require('./index.js');
+
+buildTools.loadGulpTasks(gulp);
+
+gulp.task('test', ['lint']);

--- a/index.js
+++ b/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  loadGulpTasks: require('./lib/gulp-tasks')
+};

--- a/lib/gulp-tasks.js
+++ b/lib/gulp-tasks.js
@@ -1,0 +1,66 @@
+module.exports = function(gulp) {
+  'use strict';
+
+  // Include Gulp & Tools We'll Use
+  var jscs = require('gulp-jscs');
+  var jshint = require('gulp-jshint');
+  var nodeunit = require('gulp-nodeunit');
+  var jsonlint = require('gulp-json-lint');
+  var path = require('path');
+  var replace = require('gulp-replace');
+
+  // We manually remove hard tabs from these files and make sure they are
+  // valid JSON.
+  var nonJSFiles = [
+    '.jscsrc',
+    '.jshintrc',
+    'package.json'
+  ];
+
+  var sourceFiles = [
+    'examples/**.js',
+    'lib/**.js',
+    'tests/**/*.js',
+    '*.js'
+  ];
+
+  // JS Style checks (https://github.com/jscs-dev/node-jscs#readme)
+  gulp.task('jscs', function() {
+    return gulp.src(sourceFiles)
+    .pipe(jscs({ configPath: path.join(__dirname, '../', '.jscsrc') }));
+  });
+
+  // Lint JavaScript (http://jshint.com/docs/)
+  gulp.task('jshint', function() {
+    return gulp.src(sourceFiles)
+    .pipe(jshint(path.join(__dirname, '../', '.jshintrc')))
+    .pipe(jshint.reporter('jshint-stylish'))
+    // Task should fail if JSHint finds errors.
+    .pipe(jshint.reporter('fail'));
+  });
+
+  // Make sure out package.json and our other JSON files looks nice.
+  gulp.task('jsonlint', function() {
+    return gulp.src(nonJSFiles)
+    .pipe(jsonlint())
+    .pipe(jsonlint.report('verbose'));
+  });
+
+  // Remove tabs from non-JS files (package.json and JSCS/JSHint configs).
+  gulp.task('removetabs', function() {
+    return gulp.src(nonJSFiles)
+    .pipe(replace(/\t/g, '  '))
+    .pipe(gulp.dest('.'));
+  });
+
+  // Run Unit tests
+  gulp.task('nodeunit', function() {
+    return gulp.src('tests/unit/**/test.*.js')
+    .pipe(nodeunit());
+  });
+
+  gulp.task('lint', ['jshint', 'jscs', 'jsonlint', 'removetabs']);
+  gulp.task('test', ['lint', 'nodeunit']);
+
+  gulp.task('default', ['test']);
+};

--- a/lib/gulp-tasks.js
+++ b/lib/gulp-tasks.js
@@ -27,12 +27,16 @@ module.exports = function(gulp) {
   // JS Style checks (https://github.com/jscs-dev/node-jscs#readme)
   gulp.task('jscs', function() {
     return gulp.src(sourceFiles)
+    // TODO: Scan for a local .jshintrc first before using our stock one.
+    // See https://github.com/mozilla/node-firefox-build-tools/issues/2
     .pipe(jscs({ configPath: path.join(__dirname, '../', '.jscsrc') }));
   });
 
   // Lint JavaScript (http://jshint.com/docs/)
   gulp.task('jshint', function() {
     return gulp.src(sourceFiles)
+    // TODO: Scan for a local .jshintrc first before using our stock one.
+    // See https://github.com/mozilla/node-firefox-build-tools/issues/2
     .pipe(jshint(path.join(__dirname, '../', '.jshintrc')))
     .pipe(jshint.reporter('jshint-stylish'))
     // Task should fail if JSHint finds errors.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "node-firefox-build-tools",
+  "version": "0.1.0",
+  "description": "Common configs and tasks for hacking on node-firefox",
+  "main": "index.js",
+  "scripts": {
+    "gulp": "gulp",
+    "test": "gulp test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mozilla/node-firefox-build-tools"
+  },
+  "author": "Mozilla (https://github.com/mozilla/node-firefox-build-tools/graphs/contributors)",
+  "license": "Apache 2.0",
+  "dependencies": {
+    "gulp": "^3.8.10",
+    "gulp-jscs": "^1.4.0",
+    "gulp-jshint": "^1.9.0",
+    "gulp-json-lint": "0.0.1",
+    "gulp-nodeunit": "0.0.5",
+    "gulp-replace": "^0.5.0",
+    "jshint-stylish": "^1.0.0"
+  }
+}


### PR DESCRIPTION
These should be published to npm once this is reviewed and merged, so our other repos can start using it.

This allows repos to include our common JSHint/JS Code Style rules, our gulp tasks, and be ready to run tests on Travis.
